### PR TITLE
style: apply festive poster design

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,8 +4,53 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GrabTicket</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;700&display=swap"
+      rel="stylesheet"
+    >
+    <style>
+      body {
+        margin: 0;
+        font-family: "Noto Sans SC", sans-serif;
+        background: linear-gradient(180deg, #FF9A3E 0%, #FFB84D 50%, #7BD8B5 100%);
+        color: #333;
+        overflow-x: hidden;
+      }
+
+      /* decorative background */
+      .bg-elements {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+      }
+      .bg-elements .star {
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        background: #fff;
+        border-radius: 50%;
+        animation: twinkle 2s infinite ease-in-out;
+      }
+
+      @keyframes twinkle {
+        0%, 100% { opacity: 0.3; }
+        50% { opacity: 1; }
+      }
+    </style>
   </head>
   <body>
+    <!-- background decoration -->
+    <div class="bg-elements">
+      <div class="star" style="top:10%;left:5%;animation-delay:0.2s"></div>
+      <div class="star" style="top:20%;left:80%;animation-delay:0.8s"></div>
+      <div class="star" style="top:50%;left:15%;animation-delay:1.2s"></div>
+      <div class="star" style="top:65%;left:70%;animation-delay:0.5s"></div>
+    </div>
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -24,7 +24,10 @@ function selectEvent(event) {
 
 <style>
 .container {
-  padding: 1rem;
-  font-family: Arial, sans-serif;
+  max-width: 750px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  text-align: center;
+  position: relative;
 }
 </style>

--- a/frontend/src/components/EventDetail.vue
+++ b/frontend/src/components/EventDetail.vue
@@ -39,9 +39,16 @@ async function buy(ticketTypeId) {
 
 <style scoped>
 .event-detail {
-  border: 1px solid #ddd;
-  padding: 1rem;
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
   margin-top: 1rem;
+  text-align: left;
+}
+.event-detail h3 {
+  margin-top: 0;
+  color: #ff5f00;
 }
 .tickets {
   margin-top: 1rem;
@@ -51,5 +58,11 @@ async function buy(ticketTypeId) {
 }
 .ticket button {
   margin-left: 1rem;
+  background: #5A9AFF;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
 }
 </style>

--- a/frontend/src/components/EventList.vue
+++ b/frontend/src/components/EventList.vue
@@ -30,6 +30,20 @@ function select(event) {
 </script>
 
 <style scoped>
+.events {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  margin-top: 1rem;
+  text-align: left;
+}
+.events h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.3rem;
+  color: #ff5f00;
+}
 .events ul {
   list-style: none;
   padding: 0;

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -40,14 +40,24 @@ async function login() {
   margin: 2rem auto;
   display: flex;
   flex-direction: column;
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 input {
   margin-bottom: 0.5rem;
   padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
 }
 button {
   padding: 0.5rem;
   cursor: pointer;
+  background: #5A9AFF;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
 }
 .error {
   color: red;


### PR DESCRIPTION
## Summary
- add festive gradient background and star decorations to index.html
- center main app container and apply poster-style card layouts
- restyle login, event list, and event detail components with bright colors and shadows

## Testing
- `npm run build` *(fails: sh: 1: vite: not found)*
- `npm install` *(fails: npm error code E403 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c78be6ee68832bbed2925d50d91fed