### PR TITLE
feat: add websocket ticket queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+pytest_cache/
+app.db
+node_modules/
+.env
+

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/auth': 'http://localhost:8000',
-      '/events': 'http://localhost:8000'
+      '/events': 'http://localhost:8000',
+      '/ws': { target: 'ws://localhost:8000', ws: true }
     }
   }
 })

--- a/README.md
+++ b/README.md
@@ -92,7 +92,13 @@ npm run dev
 
 4. **抢票**
 
-   前端登录成功后可在活动详情中选择票种并抢票。接口 `POST /events/{event_id}/tickets` 会在库存充足时创建订单。
+   前端通过 WebSocket 与后端交互抢票：
+
+   - 连接地址：`ws://localhost:8000/ws/events/{event_id}?token=<登录令牌>`
+   - 后端会持续通过该连接广播各票种剩余数量。
+   - 发送 `{"action":"grab","ticket_type_id":1}` 抢购指定票种，
+     服务端按顺序队列依次处理请求；
+     库存不足时会返回失败并附带其他仍有余票的票种信息。
 
 ## 备注
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,16 +1,183 @@
 from datetime import timedelta
-from fastapi import Depends, FastAPI, HTTPException, status
+import asyncio
+from typing import Dict, Set
+
+from fastapi import (
+    Depends,
+    FastAPI,
+    HTTPException,
+    WebSocket,
+    WebSocketDisconnect,
+    status,
+)
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 
 from . import auth, models, schemas
-from .database import Base, engine, get_db
+from .database import Base, engine, get_db, SessionLocal
 
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="GrabTicket API")
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+# Store active WebSocket connections per event
+event_connections: Dict[int, Set[WebSocket]] = {}
+
+# Queue to ensure sequential ticket processing
+ticket_queue: asyncio.Queue = asyncio.Queue()
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    """Launch background task processing the ticket queue."""
+    asyncio.create_task(_process_queue())
+
+
+async def _process_queue() -> None:
+    while True:
+        request = await ticket_queue.get()
+        try:
+            await _handle_grab_request(request)
+        finally:
+            ticket_queue.task_done()
+
+
+async def _handle_grab_request(request: dict) -> None:
+    event_id = request["event_id"]
+    ticket_type_id = request["ticket_type_id"]
+    websocket: WebSocket = request["websocket"]
+    user_id = request["user_id"]
+    db = SessionLocal()
+    try:
+        ticket_type = (
+            db.query(models.TicketType)
+            .filter(
+                models.TicketType.id == ticket_type_id,
+                models.TicketType.event_id == event_id,
+            )
+            .with_for_update()
+            .first()
+        )
+        if ticket_type and ticket_type.available_qty > 0:
+            ticket_type.available_qty -= 1
+            order = models.Order(
+                user_id=user_id, event_id=event_id, ticket_type_id=ticket_type_id
+            )
+            db.add(order)
+            db.commit()
+            db.refresh(order)
+            await websocket.send_json(
+                {"type": "grab_result", "status": "success", "order_id": order.id}
+            )
+        else:
+            alternatives = (
+                db.query(models.TicketType)
+                .filter(
+                    models.TicketType.event_id == event_id,
+                    models.TicketType.available_qty > 0,
+                )
+                .all()
+            )
+            alt_list = [
+                {
+                    "ticket_type_id": t.id,
+                    "seat_type": t.seat_type,
+                    "available_qty": t.available_qty,
+                }
+                for t in alternatives
+                if t.id != ticket_type_id
+            ]
+            await websocket.send_json(
+                {
+                    "type": "grab_result",
+                    "status": "fail",
+                    "reason": "Tickets sold out",
+                    "alternatives": alt_list,
+                }
+            )
+        await _broadcast_seat_counts(event_id, db)
+    finally:
+        db.close()
+
+
+async def _broadcast_seat_counts(event_id: int, db: Session | None = None) -> None:
+    close_db = False
+    if db is None:
+        db = SessionLocal()
+        close_db = True
+    try:
+        ticket_types = (
+            db.query(models.TicketType)
+            .filter(models.TicketType.event_id == event_id)
+            .all()
+        )
+        data = {
+            "type": "seat_counts",
+            "tickets": [
+                {
+                    "ticket_type_id": t.id,
+                    "seat_type": t.seat_type,
+                    "available_qty": t.available_qty,
+                }
+                for t in ticket_types
+            ],
+        }
+        for conn in list(event_connections.get(event_id, set())):
+            try:
+                await conn.send_json(data)
+            except Exception:
+                pass
+    finally:
+        if close_db:
+            db.close()
+
+
+def _get_user_by_token(token: str, db: Session) -> models.User | None:
+    token_data = auth.decode_access_token(token)
+    if token_data is None or token_data.username is None:
+        return None
+    return (
+        db.query(models.User)
+        .filter(models.User.username == token_data.username)
+        .first()
+    )
+
+
+@app.websocket("/ws/events/{event_id}")
+async def event_ws(websocket: WebSocket, event_id: int, token: str) -> None:
+    await websocket.accept()
+    db = SessionLocal()
+    user = _get_user_by_token(token, db)
+    if user is None:
+        await websocket.close(code=1008)
+        db.close()
+        return
+
+    connections = event_connections.setdefault(event_id, set())
+    connections.add(websocket)
+
+    try:
+        await _broadcast_seat_counts(event_id, db)
+        while True:
+            data = await websocket.receive_json()
+            if data.get("action") == "grab":
+                ticket_type_id = data.get("ticket_type_id")
+                if ticket_type_id is not None:
+                    await ticket_queue.put(
+                        {
+                            "websocket": websocket,
+                            "user_id": user.id,
+                            "event_id": event_id,
+                            "ticket_type_id": int(ticket_type_id),
+                        }
+                    )
+    except WebSocketDisconnect:
+        pass
+    finally:
+        connections.remove(websocket)
+        db.close()
 
 
 # Dependency

--- a/backend/main.py
+++ b/backend/main.py
@@ -128,7 +128,7 @@ async def _broadcast_seat_counts(event_id: int, db: Session | None = None) -> No
             try:
                 await conn.send_json(data)
             except Exception:
-                pass
+                event_connections[event_id].discard(conn)
     finally:
         if close_db:
             db.close()

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,14 @@ import vue from '@vitejs/plugin-vue'
 export default defineConfig({
   plugins: [vue()],
   server: {
-    port: 5173
+    port: 5173,
+    proxy: {
+      '/auth': 'http://localhost:8000',
+      '/events': 'http://localhost:8000',
+      '/ws': {
+        target: 'ws://localhost:8000',
+        ws: true
+      }
+    }
   }
 })


### PR DESCRIPTION
## Summary
- add WebSocket endpoint for events to broadcast seat counts and process grab requests sequentially via a server-side queue
- return alternative seats on sold-out attempts and update counts to all connections
- document WebSocket usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c78eb86c8c832b89d04c0e529fc921