### PR TITLE
feat: modernize UI and seed admin account

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,43 +14,14 @@
       body {
         margin: 0;
         font-family: "Noto Sans SC", sans-serif;
-        background: linear-gradient(180deg, #FF9A3E 0%, #FFB84D 50%, #7BD8B5 100%);
+        background: linear-gradient(135deg, #74ebd5 0%, #9face6 100%) no-repeat fixed;
+        background-size: cover;
         color: #333;
         overflow-x: hidden;
-      }
-
-      /* decorative background */
-      .bg-elements {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        pointer-events: none;
-      }
-      .bg-elements .star {
-        position: absolute;
-        width: 10px;
-        height: 10px;
-        background: #fff;
-        border-radius: 50%;
-        animation: twinkle 2s infinite ease-in-out;
-      }
-
-      @keyframes twinkle {
-        0%, 100% { opacity: 0.3; }
-        50% { opacity: 1; }
       }
     </style>
   </head>
   <body>
-    <!-- background decoration -->
-    <div class="bg-elements">
-      <div class="star" style="top:10%;left:5%;animation-delay:0.2s"></div>
-      <div class="star" style="top:20%;left:80%;animation-delay:0.8s"></div>
-      <div class="star" style="top:50%;left:15%;animation-delay:1.2s"></div>
-      <div class="star" style="top:65%;left:70%;animation-delay:0.5s"></div>
-    </div>
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,16 +11,16 @@
       @cancel="view = 'login'"
     />
     <div v-else-if="view === 'events'">
-      <button class="admin-btn" @click="view = 'admin'">管理账户</button>
+      <button v-if="isAdmin" class="admin-btn" @click="view = 'admin'">管理账户</button>
       <EventList @select-event="selectEvent" />
       <EventDetail v-if="currentEvent" :event="currentEvent" />
     </div>
-    <AdminUsers v-else-if="view === 'admin'" @close="view = 'events'" />
+    <AdminUsers v-else-if="view === 'admin' && isAdmin" @close="view = 'events'" />
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import Login from './components/Login.vue'
 import Register from './components/Register.vue'
 import EventList from './components/EventList.vue'
@@ -29,7 +29,9 @@ import AdminUsers from './components/AdminUsers.vue'
 
 const token = ref(localStorage.getItem('token'))
 const currentEvent = ref(null)
+const username = ref(localStorage.getItem('username'))
 const view = ref(token.value ? 'events' : 'login')
+const isAdmin = computed(() => username.value === 'admin')
 
 function selectEvent(event) {
   currentEvent.value = event
@@ -37,6 +39,7 @@ function selectEvent(event) {
 
 function onLoggedIn(t) {
   token.value = t
+  username.value = localStorage.getItem('username')
   view.value = 'events'
 }
 </script>
@@ -56,7 +59,7 @@ function onLoggedIn(t) {
   padding: 0.3rem 0.6rem;
   border: none;
   border-radius: 0.3rem;
-  background: #5A9AFF;
+  background: #4F46E5;
   color: #fff;
   cursor: pointer;
 }

--- a/frontend/src/components/AdminUsers.vue
+++ b/frontend/src/components/AdminUsers.vue
@@ -82,7 +82,7 @@ button {
   margin: 0 0.2rem;
   border: none;
   border-radius: 0.3rem;
-  background: #5A9AFF;
+  background: #4F46E5;
   color: #fff;
   cursor: pointer;
 }

--- a/frontend/src/components/EventList.vue
+++ b/frontend/src/components/EventList.vue
@@ -1,19 +1,57 @@
 <template>
   <div class="events">
     <h2>活动列表</h2>
-    <form class="create-form" @submit.prevent="createEvent">
-      <input v-model="form.title" placeholder="活动名称" required />
-      <input v-model="form.organizer" placeholder="主办方" required />
-      <input v-model="form.location" placeholder="地点" required />
-      <input type="datetime-local" v-model="form.sale_start_time" required />
-      <input type="datetime-local" v-model="form.start_time" required />
-      <input type="datetime-local" v-model="form.end_time" required />
-      <input type="file" @change="onFileChange" />
-      <input type="file" @change="onSeatMapChange" />
+    <form v-if="isAdmin" class="create-form" @submit.prevent="createEvent">
+      <div class="field">
+        <label>活动名称
+          <input v-model="form.title" required />
+        </label>
+      </div>
+      <div class="field">
+        <label>主办方
+          <input v-model="form.organizer" required />
+        </label>
+      </div>
+      <div class="field">
+        <label>地点
+          <input v-model="form.location" required />
+        </label>
+      </div>
+      <div class="field">
+        <label>开售时间
+          <input type="datetime-local" v-model="form.sale_start_time" required />
+        </label>
+      </div>
+      <div class="field">
+        <label>开始时间
+          <input type="datetime-local" v-model="form.start_time" required />
+        </label>
+      </div>
+      <div class="field">
+        <label>结束时间
+          <input type="datetime-local" v-model="form.end_time" required />
+        </label>
+      </div>
+      <div class="field">
+        <label>封面图片
+          <input type="file" @change="onFileChange" />
+        </label>
+      </div>
+      <div class="field">
+        <label>座位图
+          <input type="file" @change="onSeatMapChange" />
+        </label>
+      </div>
       <div class="block-form">
-        <input v-model="newTicket.seat_type" placeholder="票档名称" />
-        <input type="number" v-model.number="newTicket.price" placeholder="价格" />
-        <input type="number" v-model.number="newTicket.available_qty" placeholder="数量" />
+        <label>票档名称
+          <input v-model="newTicket.seat_type" />
+        </label>
+        <label>价格
+          <input type="number" v-model.number="newTicket.price" />
+        </label>
+        <label>数量
+          <input type="number" v-model.number="newTicket.available_qty" />
+        </label>
         <button type="button" @click="addTicket">添加票档</button>
       </div>
       <ul class="ticket-list" v-if="ticketTypes.length">
@@ -58,6 +96,7 @@ const seatMapFile = ref(null)
 const seatMapPreview = ref(null)
 const ticketTypes = ref([])
 const newTicket = ref({ seat_type: '', price: 0, available_qty: 0 })
+const isAdmin = localStorage.getItem('username') === 'admin'
 
 onMounted(loadEvents)
 
@@ -140,13 +179,22 @@ async function createEvent() {
   gap: 0.5rem;
   margin-bottom: 1rem;
 }
+.create-form .field {
+  flex: 1 1 200px;
+  display: flex;
+  flex-direction: column;
+}
+.create-form label {
+  font-size: 0.85rem;
+  margin-bottom: 0.2rem;
+}
 .create-form input {
   padding: 0.3rem;
   border: 1px solid #ccc;
   border-radius: 0.3rem;
 }
 .create-form button {
-  background: #5A9AFF;
+  background: #4F46E5;
   color: #fff;
   border: none;
   border-radius: 0.5rem;
@@ -159,6 +207,16 @@ async function createEvent() {
   flex-wrap: wrap;
   margin-top: 0.5rem;
   align-items: center;
+}
+.block-form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+}
+.block-form input {
+  padding: 0.3rem;
+  border: 1px solid #ccc;
+  border-radius: 0.3rem;
 }
 .seat-map {
   position: relative;

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -2,8 +2,14 @@
   <div class="login">
     <h2>登录</h2>
     <form @submit.prevent="login">
-      <input v-model="username" placeholder="用户名" />
-      <input v-model="password" type="password" placeholder="密码" />
+      <label>
+        用户名
+        <input v-model="username" placeholder="请输入用户名" />
+      </label>
+      <label>
+        密码
+        <input v-model="password" type="password" placeholder="请输入密码" />
+      </label>
       <button type="submit">登录</button>
     </form>
     <p v-if="error" class="error">{{ error }}</p>
@@ -28,6 +34,7 @@ async function login() {
     form.append('password', password.value)
     const res = await axios.post('/auth/login', form)
     localStorage.setItem('token', res.data.access_token)
+    localStorage.setItem('username', username.value)
     emit('logged-in', res.data.access_token)
   } catch (e) {
     error.value = '登录失败'
@@ -46,8 +53,14 @@ async function login() {
   border-radius: 1rem;
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
-input {
+label {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  font-size: 0.9rem;
   margin-bottom: 0.5rem;
+}
+input {
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 0.5rem;
@@ -55,7 +68,7 @@ input {
 button {
   padding: 0.5rem;
   cursor: pointer;
-  background: #5A9AFF;
+  background: #4F46E5;
   color: #fff;
   border: none;
   border-radius: 0.5rem;

--- a/frontend/src/components/Register.vue
+++ b/frontend/src/components/Register.vue
@@ -2,9 +2,18 @@
   <div class="login">
     <h2>注册</h2>
     <form @submit.prevent="register">
-      <input v-model="username" placeholder="用户名" required />
-      <input v-model="password" type="password" placeholder="密码" required />
-      <input v-model.number="energyCoins" type="number" placeholder="水晶能量币" required />
+      <label>
+        用户名
+        <input v-model="username" placeholder="请输入用户名" required />
+      </label>
+      <label>
+        密码
+        <input v-model="password" type="password" placeholder="请输入密码" required />
+      </label>
+      <label>
+        能量币
+        <input v-model.number="energyCoins" type="number" placeholder="请输入能量币数量" required />
+      </label>
       <button type="submit">注册</button>
     </form>
     <p v-if="error" class="error">{{ error }}</p>
@@ -48,8 +57,14 @@ async function register() {
   border-radius: 1rem;
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
-input {
+label {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  font-size: 0.9rem;
   margin-bottom: 0.5rem;
+}
+input {
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 0.5rem;
@@ -57,7 +72,7 @@ input {
 button {
   padding: 0.5rem;
   cursor: pointer;
-  background: #5A9AFF;
+  background: #4F46E5;
   color: #fff;
   border: none;
   border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- modern gradient background and refined styling
- add default admin user with 10k coins and restrict event creation to admin
- label registration and event creation fields and hide creation form for non-admins

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c7b4fe2604832b80f36baa012107e9