### PR TITLE
feat: add logout button and replace alerts with Vue modals

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="container">
+    <button v-if="token" class="logout-btn" @click="logout">退出登录</button>
     <Login
       v-if="view === 'login'"
       @logged-in="onLoggedIn"
@@ -42,6 +43,15 @@ function onLoggedIn(t) {
   username.value = localStorage.getItem('username')
   view.value = 'events'
 }
+
+function logout() {
+  token.value = null
+  username.value = null
+  currentEvent.value = null
+  localStorage.removeItem('token')
+  localStorage.removeItem('username')
+  view.value = 'login'
+}
 </script>
 
 <style>
@@ -60,6 +70,17 @@ function onLoggedIn(t) {
   border: none;
   border-radius: 0.3rem;
   background: #4F46E5;
+  color: #fff;
+  cursor: pointer;
+}
+.logout-btn {
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  padding: 0.3rem 0.6rem;
+  border: none;
+  border-radius: 0.3rem;
+  background: #DC2626;
   color: #fff;
   cursor: pointer;
 }

--- a/frontend/src/components/EventDetail.vue
+++ b/frontend/src/components/EventDetail.vue
@@ -20,11 +20,20 @@
     </button>
     <p v-if="!started">距离开抢还有：{{ formatTime(timeLeft) }}</p>
     <p v-if="message">{{ message }}</p>
+
+    <Modal v-if="showConfirm" @close="showConfirm = false">
+      <p>需要支付{{ selected.price }}水晶能量币，是否继续？</p>
+      <div class="modal-actions">
+        <button @click="doGrab">确认</button>
+        <button @click="showConfirm = false">取消</button>
+      </div>
+    </Modal>
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted, onUnmounted, computed } from 'vue'
+import Modal from './Modal.vue'
 
 const props = defineProps({
   event: Object
@@ -35,6 +44,7 @@ const tickets = ref([])
 const timeLeft = ref(0)
 const started = computed(() => timeLeft.value <= 0)
 const selected = ref(null)
+const showConfirm = ref(false)
 let ws
 let timer
 
@@ -87,10 +97,13 @@ function confirm() {
     message.value = '未到开抢时间'
     return
   }
+  showConfirm.value = true
+}
+
+function doGrab() {
   const t = selected.value
-  if (window.confirm(`需要支付${t.price}水晶能量币，是否继续？`)) {
-    grab(t.id)
-  }
+  showConfirm.value = false
+  grab(t.id)
 }
 
 function formatTime(ms) {
@@ -158,5 +171,18 @@ function formatTime(ms) {
 .confirm-btn:disabled {
   background: #ccc;
   cursor: not-allowed;
+}
+.modal-actions {
+  margin-top: 1rem;
+  text-align: center;
+}
+.modal-actions button {
+  margin: 0 0.3rem;
+  padding: 0.3rem 0.6rem;
+  border: none;
+  border-radius: 0.3rem;
+  background: #4F46E5;
+  color: #fff;
+  cursor: pointer;
 }
 </style>

--- a/frontend/src/components/Modal.vue
+++ b/frontend/src/components/Modal.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="overlay" @click.self="$emit('close')">
+    <div class="modal">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 200px;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add logout button and logic in App.vue
- replace JS alert/prompt/confirm with Vue-based modal component
- create reusable Modal.vue component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7b790e318832b9125a45000413b11