### PR TITLE
Improve registration page and admin user pagination

### DIFF
--- a/frontend/src/components/AdminUsers.vue
+++ b/frontend/src/components/AdminUsers.vue
@@ -11,7 +11,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="u in users" :key="u.id">
+        <tr v-for="u in paginatedUsers" :key="u.id">
           <td>{{ u.id }}</td>
           <td>{{ u.username }}</td>
           <td>{{ u.energy_coins }}</td>
@@ -21,6 +21,11 @@
         </tr>
       </tbody>
     </table>
+    <div class="pagination">
+      <button @click="prevPage" :disabled="currentPage === 1">上一页</button>
+      <span>{{ currentPage }} / {{ totalPages }}</span>
+      <button @click="nextPage" :disabled="currentPage === totalPages">下一页</button>
+    </div>
     <button @click="$emit('close')">返回</button>
 
     <Modal v-if="showEditor" @close="showEditor = false">
@@ -42,7 +47,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import axios from 'axios'
 import Modal from './Modal.vue'
 
@@ -52,6 +57,14 @@ const showMessage = ref(false)
 const message = ref('')
 const newCoins = ref(0)
 const currentUser = ref(null)
+const currentPage = ref(1)
+const pageSize = 10
+
+const totalPages = computed(() => Math.ceil(users.value.length / pageSize) || 1)
+const paginatedUsers = computed(() => {
+  const start = (currentPage.value - 1) * pageSize
+  return users.value.slice(start, start + pageSize)
+})
 
 onMounted(loadUsers)
 
@@ -67,6 +80,14 @@ function openModify(user) {
   currentUser.value = user
   newCoins.value = user.energy_coins
   showEditor.value = true
+}
+
+function nextPage() {
+  if (currentPage.value < totalPages.value) currentPage.value++
+}
+
+function prevPage() {
+  if (currentPage.value > 1) currentPage.value--
 }
 
 async function submitModify() {
@@ -112,6 +133,17 @@ button {
   background: #4F46E5;
   color: #fff;
   cursor: pointer;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.pagination span {
+  margin: 0 0.5rem;
 }
 
 .modal-actions {

--- a/frontend/src/components/Register.vue
+++ b/frontend/src/components/Register.vue
@@ -17,7 +17,7 @@
       <button type="submit">注册</button>
     </form>
     <p v-if="error" class="error">{{ error }}</p>
-    <button @click="$emit('cancel')">返回登录</button>
+    <button class="back" @click="$emit('cancel')">返回登录</button>
   </div>
 </template>
 
@@ -41,7 +41,7 @@ async function register() {
     })
     emit('registered')
   } catch (e) {
-    error.value = '注册失败'
+    error.value = e.response?.data?.detail || '注册失败'
   }
 }
 </script>
@@ -76,6 +76,9 @@ button {
   color: #fff;
   border: none;
   border-radius: 0.5rem;
+}
+.back {
+  margin-top: 0.5rem;
 }
 .error {
   color: red;


### PR DESCRIPTION
## Summary
- add margin between register and back buttons and show server error details on registration
- paginate admin user table to 10 users per page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7be6a0048832b893b5879d45704d1