### PR TITLE
Add energy coin checks and event editing

### DIFF
--- a/frontend/src/components/EventDetail.vue
+++ b/frontend/src/components/EventDetail.vue
@@ -76,7 +76,11 @@ onMounted(() => {
         message.value = '抢票成功！订单号: ' + data.order_id
       } else {
         const alts = (data.alternatives || []).map(a => `${a.seat_type}(${a.available_qty})`).join(', ')
-        message.value = '抢票失败，座位已满' + (alts ? '，可选：' + alts : '')
+        if (data.reason === 'Tickets sold out') {
+          message.value = '抢票失败，座位已满' + (alts ? '，可选：' + alts : '')
+        } else {
+          message.value = '抢票失败：' + data.reason
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- validate and deduct user energy coins when grabbing tickets
- show detailed failure reasons on the ticket grab UI
- allow admin to edit existing events from the frontend

## Testing
- `python -m pytest`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c7c055a820832bb197646ec691b255