### PR TITLE
Fix proxy and countdown parsing

### DIFF
--- a/frontend/src/components/EventDetail.vue
+++ b/frontend/src/components/EventDetail.vue
@@ -53,12 +53,9 @@ let timer
 
 onMounted(() => {
   tickets.value = props.event.ticket_types || []
-  const saleStart = new Date(
-    String(props.event.sale_start_time).replace(' ', 'T')
-  ).getTime()
+  const saleStart = Date.parse(props.event.sale_start_time)
   const updateCountdown = () => {
-    const diff = saleStart - Date.now()
-    timeLeft.value = diff > 0 ? diff : 0
+    timeLeft.value = Math.max(0, saleStart - Date.now())
   }
   updateCountdown()
   timer = setInterval(updateCountdown, 1000)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
     proxy: {
       '/auth': 'http://localhost:8000',
       '/events': 'http://localhost:8000',
+      '/users': 'http://localhost:8000',
       '/ws': {
         target: 'ws://localhost:8000',
         ws: true


### PR DESCRIPTION
## Summary
- proxy `/users` requests to backend for energy coin retrieval
- correct event sale start parsing to show countdown

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7ccb845cc832b9e3d7c6b083dbeef