### PR TITLE
fix: proxy static assets during development

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
       '/auth': 'http://localhost:8000',
       '/events': 'http://localhost:8000',
       '/users': 'http://localhost:8000',
+      '/static': 'http://localhost:8000',
       '/ws': {
         target: 'ws://localhost:8000',
         ws: true


### PR DESCRIPTION
## Summary
- proxy `/static` requests in Vite dev server to backend to load images stored outside the frontend directory

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c7d0997b88832b8b0e415f3a8891e2