### PR TITLE
Fix ticket selection and order modal

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,16 +15,17 @@
     <div v-else-if="view === 'events'">
       <button v-if="isAdmin" class="admin-btn" @click="view = 'admin'">管理账户</button>
       <EventList @select-event="selectEvent" />
-      <EventDetail v-if="currentEvent" :event="currentEvent" />
+      <EventDetail v-if="currentEvent" :event="currentEvent" :key="currentEvent.id" />
     </div>
     <AdminUsers v-else-if="view === 'admin' && isAdmin" @close="view = 'events'" />
     <Modal v-if="showOrders" @close="showOrders = false">
       <h3>抢票记录</h3>
-      <ul>
+      <ul v-if="orders.length">
         <li v-for="o in orders" :key="o.id">
           {{ o.event.title }} - {{ o.ticket_type.seat_type }} - {{ new Date(o.created_at + 'Z').toLocaleString() }}
         </li>
       </ul>
+      <p v-else>暂无抢票记录</p>
     </Modal>
   </div>
 </template>
@@ -67,12 +68,17 @@ function logout() {
 }
 
 async function openOrders() {
-  const token = localStorage.getItem('token')
-  const res = await axios.get('/orders/me', {
-    headers: { Authorization: `Bearer ${token}` }
-  })
-  orders.value = res.data
-  showOrders.value = true
+  const tok = localStorage.getItem('token')
+  try {
+    const res = await axios.get('/orders/me', {
+      headers: { Authorization: `Bearer ${tok}` }
+    })
+    orders.value = res.data
+  } catch (e) {
+    orders.value = []
+  } finally {
+    showOrders.value = true
+  }
 }
 </script>
 

--- a/frontend/src/components/EventDetail.vue
+++ b/frontend/src/components/EventDetail.vue
@@ -10,13 +10,13 @@
         v-for="t in tickets"
         :key="t.id"
         class="ticket-btn"
-        :class="{ active: selected && selected.id === t.id, disabled: !started }"
-        @click="started && (selected = t)"
+        :class="{ active: selected && selected.id === t.id, disabled: !started || t.available_qty === 0 }"
+        @click="started && t.available_qty > 0 && (selected = t)"
       >
         {{ t.seat_type }} ¥{{ t.price }} (剩余{{ t.available_qty }})
       </button>
     </div>
-    <button class="confirm-btn" :disabled="!started || !selected" @click="confirm">
+    <button class="confirm-btn" :disabled="!started || !selected || selected.available_qty === 0" @click="confirm">
       确定
     </button>
     <p v-if="!started">距离开抢还有：{{ formatTime(timeLeft) }}</p>
@@ -76,7 +76,11 @@ onMounted(() => {
       })
       if (selected.value) {
         const matchSel = tickets.value.find(tt => tt.id === selected.value.id)
-        if (matchSel) selected.value = matchSel
+        if (matchSel && matchSel.available_qty > 0) {
+          selected.value = matchSel
+        } else if (matchSel) {
+          selected.value = null
+        }
       }
     } else if (data.type === 'grab_result') {
       if (data.status === 'success') {


### PR DESCRIPTION
## Summary
- Disable selection and confirmation for sold-out tickets
- Handle order retrieval errors and show empty state
- Refresh event details when switching events

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d78fe078832ba3a4e401f7cf5f9f