### PR TITLE
Handle login and websocket errors

### DIFF
--- a/frontend/src/components/EventDetail.vue
+++ b/frontend/src/components/EventDetail.vue
@@ -60,6 +60,10 @@ onMounted(() => {
   updateCountdown()
   timer = setInterval(updateCountdown, 1000)
   const token = localStorage.getItem('token')
+  if (!token) {
+    message.value = '请先登录'
+    return
+  }
   axios.get('/users/me', {
     headers: { Authorization: `Bearer ${token}` }
   }).then(res => {
@@ -67,6 +71,14 @@ onMounted(() => {
   })
   const wsUrl = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws/events/${props.event.id}?token=${token}`
   ws = new WebSocket(wsUrl)
+  ws.onerror = () => {
+    message.value = '连接服务器失败'
+  }
+  ws.onclose = (evt) => {
+    if (!evt.wasClean) {
+      message.value = '连接已断开'
+    }
+  }
   ws.onmessage = (evt) => {
     const data = JSON.parse(evt.data)
     if (data.type === 'seat_counts') {

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -37,7 +37,13 @@ async function login() {
     localStorage.setItem('username', username.value)
     emit('logged-in', res.data.access_token)
   } catch (e) {
-    error.value = '登录失败'
+    if (e.response?.data?.detail) {
+      error.value = e.response.data.detail
+    } else if (e.response?.status === 422) {
+      error.value = '请输入用户名和密码'
+    } else {
+      error.value = '登录失败'
+    }
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- Improve login error handling by showing backend-provided messages and handling missing credentials
- Warn users to login before connecting to event WebSocket and surface connection issues

## Testing
- `npm run build`
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7f4836764832bb389e049fef6d3ac