### PR TITLE
fix websocket connection to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ npm run dev
 
 浏览器访问 <http://localhost:5173> 即可看到界面。若需构建静态文件，可运行 `npm run build`，输出位于 `frontend/dist`。
 
+如果后端与前端不在同一主机或端口，可在 `frontend/.env` 中设置 `VITE_WS_HOST` 指定 WebSocket 服务地址，例如：
+
+```
+VITE_WS_HOST=localhost:8000
+```
+
 ## 使用流程
 
 1. **注册用户**

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for the frontend
+# Set the backend WebSocket host (host:port) used for real-time updates.
+# If unset, the frontend will use the current window.location.host.
+# For local development when backend runs on port 8000:
+VITE_WS_HOST=localhost:8000

--- a/frontend/src/components/EventDetail.vue
+++ b/frontend/src/components/EventDetail.vue
@@ -69,7 +69,12 @@ onMounted(() => {
   }).then(res => {
     coins.value = res.data.energy_coins
   })
-  const wsUrl = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws/events/${props.event.id}?token=${token}`
+  // Allow the websocket host to be configured via VITE_WS_HOST so the
+  // connection works when the frontend and backend run on different hosts or
+  // ports. If the variable is not set we fall back to the current location.
+  const wsProtocol = location.protocol === 'https:' ? 'wss' : 'ws'
+  const wsHost = import.meta.env.VITE_WS_HOST || location.host
+  const wsUrl = `${wsProtocol}://${wsHost}/ws/events/${props.event.id}?token=${token}`
   ws = new WebSocket(wsUrl)
   ws.onerror = () => {
     message.value = '连接服务器失败'


### PR DESCRIPTION
## Summary
- read `VITE_WS_HOST` to allow websocket host override and fall back to current location
- document `VITE_WS_HOST` in frontend `.env.example` and README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fbda9194832ba1b1266a39416cf8