### PR TITLE
Fix orders proxy in Vite config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ export default defineConfig({
     proxy: {
       '/auth': 'http://localhost:8000',
       '/events': 'http://localhost:8000',
+      '/orders': 'http://localhost:8000',
       '/ws': { target: 'ws://localhost:8000', ws: true }
     }
   }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
     proxy: {
       '/auth': 'http://localhost:8000',
       '/events': 'http://localhost:8000',
+      '/orders': 'http://localhost:8000',
       '/users': 'http://localhost:8000',
       '/static': 'http://localhost:8000',
       '/ws': {


### PR DESCRIPTION
## Summary
- proxy /orders endpoints to the backend in the Vite dev server so order history requests resolve correctly
- update the README proxy example to include the /orders entry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8a96c5d2c832b928f8697a00a6683