### PR TITLE
feat: allow admin to view and export ticket orders

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,10 @@ import os
 import uuid
 import shutil
 import json
+import io
+import zipfile
 from typing import Dict, Set
+from xml.sax.saxutils import escape
 
 from fastapi import (
     Depends,
@@ -20,6 +23,7 @@ from fastapi import (
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session, joinedload
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import StreamingResponse
 
 from . import auth, models, schemas
 from .database import Base, engine, get_db, SessionLocal
@@ -36,6 +40,148 @@ event_connections: Dict[int, Set[WebSocket]] = {}
 
 # Queue to ensure sequential ticket processing
 ticket_queue: asyncio.Queue = asyncio.Queue()
+
+
+_CONTENT_TYPES_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+    '<Default Extension="xml" ContentType="application/xml"/>'
+    '<Override PartName="/xl/workbook.xml" '
+    'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>'
+    '<Override PartName="/xl/worksheets/sheet1.xml" '
+    'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>'
+    '<Override PartName="/xl/styles.xml" '
+    'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>'
+    '</Types>'
+)
+
+_ROOT_RELS_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" '
+    'Target="xl/workbook.xml"/>'
+    '</Relationships>'
+)
+
+_WORKBOOK_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" '
+    'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+    '<sheets>'
+    '<sheet name="订单记录" sheetId="1" r:id="rId1"/>'
+    '</sheets>'
+    '</workbook>'
+)
+
+_WORKBOOK_RELS_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" '
+    'Target="worksheets/sheet1.xml"/>'
+    '<Relationship Id="rId2" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" '
+    'Target="styles.xml"/>'
+    '</Relationships>'
+)
+
+_STYLES_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+    '<fonts count="1"><font><sz val="11"/><color theme="1"/><name val="Calibri"/><family val="2"/></font></fonts>'
+    '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>'
+    '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>'
+    '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>'
+    '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>'
+    '<cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>'
+    '</styleSheet>'
+)
+
+
+def _column_letter(index: int) -> str:
+    result = ""
+    while index > 0:
+        index, remainder = divmod(index - 1, 26)
+        result = chr(65 + remainder) + result
+    return result or "A"
+
+
+def _build_sheet_xml(rows: list[list[str]]) -> str:
+    max_cols = max((len(r) for r in rows), default=1)
+    if rows:
+        dimension = f"A1:{_column_letter(max_cols)}{len(rows)}"
+    else:
+        dimension = "A1:A1"
+    rows_xml: list[str] = []
+    for row_idx, row_values in enumerate(rows, start=1):
+        cells_xml: list[str] = []
+        for col_idx in range(1, max_cols + 1):
+            value = row_values[col_idx - 1] if col_idx - 1 < len(row_values) else ""
+            cell_ref = f"{_column_letter(col_idx)}{row_idx}"
+            text = "" if value is None else escape(str(value))
+            cells_xml.append(
+                f'<c r="{cell_ref}" t="inlineStr"><is><t xml:space="preserve">{text}'
+                "</t></is></c>"
+            )
+        rows_xml.append(f"<row r=\"{row_idx}\">{''.join(cells_xml)}</row>")
+    sheet_data = "".join(rows_xml)
+    if sheet_data:
+        sheet_data = f"<sheetData>{sheet_data}</sheetData>"
+    else:
+        sheet_data = "<sheetData/>"
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        f"<dimension ref=\"{dimension}\"/>"
+        f"{sheet_data}"
+        "</worksheet>"
+    )
+
+
+def _orders_to_rows(orders: list[models.Order]) -> list[list[str]]:
+    rows: list[list[str]] = [["订单ID", "用户名", "活动名称", "票档", "票价", "抢票时间"]]
+    for order in orders:
+        username = order.user.username if order.user else ""
+        event_title = order.event.title if order.event else ""
+        seat_type = order.ticket_type.seat_type if order.ticket_type else ""
+        price = ""
+        if order.ticket_type and order.ticket_type.price is not None:
+            price = f"{order.ticket_type.price:.2f}"
+        created_at = (
+            order.created_at.strftime("%Y-%m-%d %H:%M:%S")
+            if order.created_at
+            else ""
+        )
+        rows.append([
+            str(order.id),
+            username,
+            event_title,
+            seat_type,
+            price,
+            created_at,
+        ])
+    return rows
+
+
+def _build_orders_workbook(orders: list[models.Order]) -> io.BytesIO:
+    buffer = io.BytesIO()
+    sheet_xml = _build_sheet_xml(_orders_to_rows(orders))
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("[Content_Types].xml", _CONTENT_TYPES_XML)
+        archive.writestr("_rels/.rels", _ROOT_RELS_XML)
+        archive.writestr("xl/workbook.xml", _WORKBOOK_XML)
+        archive.writestr("xl/_rels/workbook.xml.rels", _WORKBOOK_RELS_XML)
+        archive.writestr("xl/styles.xml", _STYLES_XML)
+        archive.writestr("xl/worksheets/sheet1.xml", sheet_xml)
+    buffer.seek(0)
+    return buffer
+
+
+def _ensure_admin(user: models.User) -> None:
+    if user.username != "admin":
+        raise HTTPException(status_code=403, detail="只有管理员可以执行该操作")
 
 
 @app.on_event("startup")
@@ -336,6 +482,53 @@ def admin_delete_user(
     db.commit()
 
 
+@app.get("/admin/orders", response_model=list[schemas.Order])
+def admin_list_orders(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    _ensure_admin(current_user)
+    orders = (
+        db.query(models.Order)
+        .options(
+            joinedload(models.Order.user),
+            joinedload(models.Order.event),
+            joinedload(models.Order.ticket_type),
+        )
+        .order_by(models.Order.created_at.desc())
+        .all()
+    )
+    return orders
+
+
+@app.get("/admin/orders/export")
+def admin_export_orders(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    _ensure_admin(current_user)
+    orders = (
+        db.query(models.Order)
+        .options(
+            joinedload(models.Order.user),
+            joinedload(models.Order.event),
+            joinedload(models.Order.ticket_type),
+        )
+        .order_by(models.Order.created_at.desc())
+        .all()
+    )
+    workbook = _build_orders_workbook(orders)
+    filename = f"orders_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}.xlsx"
+    headers = {
+        "Content-Disposition": f'attachment; filename="{filename}"',
+    }
+    return StreamingResponse(
+        workbook,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers=headers,
+    )
+
+
 @app.get("/events", response_model=list[schemas.Event])
 def read_events(db: Session = Depends(get_db)):
     events = db.query(models.Event).all()
@@ -532,6 +725,7 @@ def read_my_orders(
     orders = (
         db.query(models.Order)
         .options(
+            joinedload(models.Order.user),
             joinedload(models.Order.event),
             joinedload(models.Order.ticket_type),
         )

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -70,6 +70,7 @@ class Order(BaseModel):
     event: Event
     ticket_type: TicketType
     created_at: datetime
+    user: Optional[User] = None
 
     class Config:
         orm_mode = True

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,11 +13,21 @@
       @cancel="view = 'login'"
     />
     <div v-else-if="view === 'events'">
-      <button v-if="isAdmin" class="admin-btn" @click="view = 'admin'">管理账户</button>
+      <button
+        v-if="isAdmin"
+        class="admin-btn"
+        @click="view = 'admin-users'"
+      >账户管理</button>
+      <button
+        v-if="isAdmin"
+        class="admin-orders-btn"
+        @click="view = 'admin-orders'"
+      >抢票记录</button>
       <EventList @select-event="selectEvent" />
       <EventDetail v-if="currentEvent" :event="currentEvent" :key="currentEvent.id" />
     </div>
-    <AdminUsers v-else-if="view === 'admin' && isAdmin" @close="view = 'events'" />
+    <AdminUsers v-else-if="view === 'admin-users' && isAdmin" @close="view = 'events'" />
+    <AdminOrders v-else-if="view === 'admin-orders' && isAdmin" @close="view = 'events'" />
     <Modal v-if="showOrders" @close="showOrders = false">
       <h3>抢票记录</h3>
       <ul v-if="orders.length">
@@ -39,6 +49,7 @@ import Register from './components/Register.vue'
 import EventList from './components/EventList.vue'
 import EventDetail from './components/EventDetail.vue'
 import AdminUsers from './components/AdminUsers.vue'
+import AdminOrders from './components/AdminOrders.vue'
 import Modal from './components/Modal.vue'
 
 const token = ref(localStorage.getItem('token'))
@@ -135,6 +146,17 @@ function formatOrderDate(value) {
   border: none;
   border-radius: 0.3rem;
   background: #4F46E5;
+  color: #fff;
+  cursor: pointer;
+}
+.admin-orders-btn {
+  position: absolute;
+  right: 1rem;
+  top: 2.4rem;
+  padding: 0.3rem 0.6rem;
+  border: none;
+  border-radius: 0.3rem;
+  background: #2563EB;
   color: #fff;
   cursor: pointer;
 }

--- a/frontend/src/components/AdminOrders.vue
+++ b/frontend/src/components/AdminOrders.vue
@@ -1,0 +1,237 @@
+<template>
+  <div class="admin-orders">
+    <h2>抢票记录</h2>
+    <div class="actions">
+      <button @click="loadOrders" :disabled="loading">
+        {{ loading ? '加载中...' : '刷新' }}
+      </button>
+      <button
+        @click="exportExcel"
+        :disabled="exporting || !orders.length"
+      >
+        {{ exporting ? '导出中...' : '导出Excel' }}
+      </button>
+      <button class="secondary" @click="$emit('close')">返回</button>
+    </div>
+    <p v-if="error" class="error">{{ error }}</p>
+    <table v-if="!loading && paginatedOrders.length">
+      <thead>
+        <tr>
+          <th>订单ID</th>
+          <th>用户名</th>
+          <th>活动名称</th>
+          <th>票档</th>
+          <th>票价</th>
+          <th>抢票时间</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="order in paginatedOrders" :key="order.id">
+          <td>{{ order.id }}</td>
+          <td>{{ order.user?.username || '未知用户' }}</td>
+          <td>{{ order.event?.title || '未知活动' }}</td>
+          <td>{{ order.ticket_type?.seat_type || '--' }}</td>
+          <td>{{ formatPrice(order.ticket_type?.price) }}</td>
+          <td>{{ formatDate(order.created_at) }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <p v-else-if="loading" class="status">加载中...</p>
+    <p v-else class="status">暂无抢票记录</p>
+    <div class="pagination" v-if="!loading && totalPages > 1">
+      <button @click="prevPage" :disabled="currentPage === 1">上一页</button>
+      <span>{{ currentPage }} / {{ totalPages }}</span>
+      <button @click="nextPage" :disabled="currentPage === totalPages">下一页</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import axios from 'axios'
+
+const orders = ref([])
+const loading = ref(false)
+const exporting = ref(false)
+const error = ref('')
+const currentPage = ref(1)
+const pageSize = 10
+
+const totalPages = computed(() => Math.ceil(orders.value.length / pageSize) || 1)
+const paginatedOrders = computed(() => {
+  const start = (currentPage.value - 1) * pageSize
+  return orders.value.slice(start, start + pageSize)
+})
+
+onMounted(loadOrders)
+
+async function loadOrders() {
+  loading.value = true
+  error.value = ''
+  const token = localStorage.getItem('token')
+  try {
+    const res = await axios.get('/admin/orders', {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    let raw = res.data
+    if (typeof raw === 'string') {
+      try {
+        raw = JSON.parse(raw)
+      } catch (e) {
+        raw = []
+      }
+    }
+    const list = Array.isArray(raw)
+      ? raw
+      : Array.isArray(raw?.orders)
+        ? raw.orders
+        : []
+    orders.value = list.filter((item) => item && typeof item.id === 'number')
+    currentPage.value = 1
+  } catch (e) {
+    orders.value = []
+    currentPage.value = 1
+    error.value = e.response?.data?.detail || '加载抢票记录失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatDate(value) {
+  if (!value) return '--'
+  let date
+  if (typeof value === 'number') {
+    const ts = value < 1e12 ? value * 1000 : value
+    date = new Date(ts)
+  } else if (typeof value === 'string') {
+    const hasTimezone = /(Z|[+-]\d{2}:\d{2})$/i.test(value)
+    const normalized = hasTimezone ? value : `${value}Z`
+    date = new Date(normalized)
+    if (Number.isNaN(date.getTime())) {
+      date = new Date(value)
+    }
+  } else if (value instanceof Date) {
+    date = value
+  } else {
+    return '--'
+  }
+  return Number.isNaN(date.getTime()) ? '--' : date.toLocaleString()
+}
+
+function formatPrice(value) {
+  if (value === null || value === undefined || value === '') return '--'
+  const num = Number(value)
+  if (Number.isNaN(num)) return String(value)
+  return num.toFixed(2)
+}
+
+function nextPage() {
+  if (currentPage.value < totalPages.value) currentPage.value += 1
+}
+
+function prevPage() {
+  if (currentPage.value > 1) currentPage.value -= 1
+}
+
+async function exportExcel() {
+  if (!orders.value.length) return
+  const token = localStorage.getItem('token')
+  exporting.value = true
+  error.value = ''
+  try {
+    const res = await axios.get('/admin/orders/export', {
+      headers: { Authorization: `Bearer ${token}` },
+      responseType: 'blob'
+    })
+    const blob = new Blob([res.data], {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    const stamp = new Date().toISOString().replace(/[-:]/g, '').split('.')[0]
+    link.href = url
+    link.download = `orders_${stamp}.xlsx`
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    URL.revokeObjectURL(url)
+  } catch (e) {
+    error.value = e.response?.data?.detail || '导出失败，请稍后重试'
+  } finally {
+    exporting.value = false
+  }
+}
+</script>
+
+<style scoped>
+.admin-orders {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  margin-top: 1rem;
+  text-align: left;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+button {
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: 0.4rem;
+  background: #2563eb;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.secondary {
+  background: #6b7280;
+}
+
+.error {
+  color: #dc2626;
+  margin-bottom: 0.5rem;
+}
+
+.status {
+  margin: 1rem 0;
+  color: #6b7280;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+th, td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pagination button {
+  background: #4f46e5;
+  padding: 0.3rem 0.6rem;
+}
+
+.pagination span {
+  color: #374151;
+}
+</style>


### PR DESCRIPTION
## Summary
- add admin endpoints to list ticket orders and export the data as an Excel file
- include user information in order payloads and generate XLSX content on the server
- add an admin orders view in the frontend with download support

## Testing
- npm run build
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c8b46b8280832baa36ef4916e6f393