### PR TITLE
feat: allow users to edit energy coins from event view

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -423,6 +423,23 @@ def read_current_user(current_user: models.User = Depends(get_current_user)):
     return current_user
 
 
+@app.put("/users/me/coins", response_model=schemas.User)
+def update_current_user_coins(
+    data: schemas.UserUpdateCoins,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    if data.energy_coins < 0:
+        raise HTTPException(status_code=400, detail="能量币不能为负数")
+    user = db.query(models.User).filter(models.User.id == current_user.id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="用户不存在")
+    user.energy_coins = data.energy_coins
+    db.commit()
+    db.refresh(user)
+    return user
+
+
 @app.get("/admin/users", response_model=list[schemas.User])
 def admin_list_users(
     db: Session = Depends(get_db),


### PR DESCRIPTION
## Summary
- allow authenticated users to update their own energy coins through a new `/users/me/coins` endpoint that validates non-negative values
- add a "修改能量币" button, modal workflow, and styles on the event detail view so users can adjust their balance from the ticket page

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68c8ccfd3efc832b9d5cc7f4e2d325d2