### PR TITLE
Fix admin API proxy configuration

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
       '/auth': 'http://localhost:8000',
       '/events': 'http://localhost:8000',
       '/orders': 'http://localhost:8000',
+      '/admin': 'http://localhost:8000',
       '/users': 'http://localhost:8000',
       '/static': 'http://localhost:8000',
       '/ws': {


### PR DESCRIPTION
## Summary
- proxy /admin requests in the Vite dev server to the FastAPI backend so admin order data loads correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8cf38396c832b803b5a096029577c