### PR TITLE
feat: limit per account and editable ticket tiers

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Float
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Float, Boolean
 from sqlalchemy.orm import relationship
 from datetime import datetime
 
@@ -29,6 +29,7 @@ class Event(Base):
     end_time = Column(DateTime)
     seat_map_url = Column(String, nullable=True)
     cover_image = Column(String, nullable=True)
+    limit_one_ticket_per_user = Column(Boolean, default=False)
 
     ticket_types = relationship("TicketType", back_populates="event")
     orders = relationship("Order", back_populates="event")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -55,6 +55,7 @@ class EventBase(BaseModel):
     end_time: Optional[datetime] = None
     seat_map_url: Optional[str] = None
     cover_image: Optional[str] = None
+    limit_one_ticket_per_user: bool = False
 
 
 class Event(EventBase):


### PR DESCRIPTION
## Summary
- add a per-event `limit_one_ticket_per_user` flag persisted in the database and enforced in ticket purchase flows
- expose the toggle on the admin event form alongside inline editing for ticket tiers
- surface limit messaging in the event detail view and block duplicate purchase attempts client-side when the cap is enabled

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68c8d2200e8c832baba3de1069549e9f