### PR TITLE
Serve built assets at expected path

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -64,7 +64,12 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.mount("/static", StaticFiles(directory="static"), name="static")
+static_root = "static"
+app.mount("/static", StaticFiles(directory=static_root), name="static")
+
+assets_dir = os.path.join(static_root, "assets")
+if os.path.isdir(assets_dir):
+    app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
 


### PR DESCRIPTION
## Summary
- mount the built frontend assets directory at `/assets` so the FastAPI backend can serve them where the SPA expects
- keep the existing `/static` mount while reusing the configured static root path

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c8f684fb38832babdd4f1439c04aa7