### PR TITLE
Allow orders without ticket type

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -69,7 +69,7 @@ class Event(EventBase):
 class Order(BaseModel):
     id: int
     event: Event
-    ticket_type: TicketType
+    ticket_type: Optional[TicketType] = None
     created_at: datetime
     user: Optional[User] = None
 


### PR DESCRIPTION
## Summary
- permit ticket_type on the Order schema to be optional so historical orders remain readable even if their ticket type was removed

## Testing
- python - <<'PY'
from backend.main import Base, engine, SessionLocal
from backend import models, schemas, auth
from datetime import datetime, timedelta

Base.metadata.drop_all(bind=engine)
Base.metadata.create_all(bind=engine)

session = SessionLocal()

admin = models.User(username='admin', hashed_password=auth.get_password_hash('admin'), energy_coins=1000)
user = models.User(username='user1', hashed_password=auth.get_password_hash('pass'), energy_coins=1000)
session.add_all([admin, user])
session.commit()

now = datetime.utcnow()
event = models.Event(
    title='Concert',
    organizer='Org',
    location='Loc',
    description='desc',
    sale_start_time=now - timedelta(hours=1),
    start_time=now + timedelta(hours=1),
    end_time=now + timedelta(hours=2),
)
session.add(event)
session.commit()

seat = models.TicketType(event_id=event.id, price=100, seat_type='A', available_qty=10)
session.add(seat)
session.commit()

order = models.Order(user_id=user.id, event_id=event.id, ticket_type_id=seat.id)
session.add(order)
session.commit()

session.delete(seat)
session.commit()
session.refresh(order)

schemas.Order.model_validate(order, from_attributes=True)
print('validated with missing ticket type')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d104726b48832b89f33bc1ba2bb45e